### PR TITLE
Refactor tests for pytest‑flask

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+import os
+import sys
+import pytest
+
+# Ensure project root is on sys.path for imports
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+from utils.test_utils import create_app
+from routes.llm import llm_bp
+from routes.tts import tts_bp
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.register_blueprint(llm_bp)
+    app.register_blueprint(tts_bp)
+    return app

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,15 +1,9 @@
-from routes.llm import llm_bp
-from utils.test_utils import create_app
-
-app = create_app()
-app.register_blueprint(llm_bp)
+from flask.testing import FlaskClient
 
 
-def test_reset_chat_route(app):
-    with app.test_client() as client:
-        resp = client.get('/reset_chat')
+def test_reset_chat_route(client: FlaskClient):
+    resp = client.get('/reset_chat')
     assert resp.status_code == 200
     assert resp.data == b'OK'
 
-if __name__ == "__main__":
-    test_reset_chat_route(app)
+

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -1,17 +1,12 @@
-from utils.test_utils import create_app
-from routes.tts import tts_bp
+from flask.testing import FlaskClient
 
 
-app = create_app()
-app.register_blueprint(tts_bp)
-
-def test_get_mp3_requires_text(app):
-    with app.test_client() as client:
-        resp = client.get('/output.mp3')
+def test_get_mp3_requires_text(client: FlaskClient):
+    resp = client.get('/output.mp3')
     assert resp.status_code == 400
 
 
-def test_get_mp3_with_text(app):
-    with app.test_client() as client:
-        resp = client.get('/output.mp3?text=ola')
+def test_get_mp3_with_text(client: FlaskClient):
+    resp = client.get('/output.mp3?text=ola')
     assert resp.status_code in (200, 404)
+

--- a/utils/test_utils.py
+++ b/utils/test_utils.py
@@ -1,5 +1,9 @@
 from flask import Flask
+import os
 
-def create_app():
-    app = Flask(__name__)
-    return app
+
+def create_app() -> Flask:
+    """Create a barebones Flask application for testing."""
+    root_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    return Flask(__name__, root_path=root_path)
+


### PR DESCRIPTION
## Summary
- simplify `create_app` helper
- switch tests to pytest-flask fixtures
- register blueprints in a new `conftest.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68545ea197e08321b77483c18cb031c9